### PR TITLE
Simplify treatment of reserved words to follow Python convention.

### DIFF
--- a/automagic_rest/management/commands/build_data_models.py
+++ b/automagic_rest/management/commands/build_data_models.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 from django.db import connections
 from django.template.loader import render_to_string
 
-from automagic_rest.settings import get_reserved_words
+from automagic_rest.settings import get_reserved_words_to_append_underscore
 
 # Map PostgreSQL column types to Django ORM field type
 # Please note: "blank=True, null=True" must be typed
@@ -39,7 +39,7 @@ COLUMN_FIELD_MAP = {
 }
 
 # Words that can't be used as column names
-RESERVED_WORDS = get_reserved_words()
+RESERVED_WORDS = get_reserved_words_to_append_underscore()
 
 
 def fetch_result_with_blank_row(cursor):
@@ -75,7 +75,10 @@ class Command(BaseCommand):
             action="store",
             dest="owner",
             default="my_pg_user",
-            help='Select schemata from this PostgreSQL owner user. Defaults to the "wrdsadmn" owner.',
+            help=(
+                'Select schemata from this PostgreSQL owner user. Defaults to the '
+                '"wrdsadmn" owner.'
+            ),
         )
         parser.add_argument(
             "--path",
@@ -89,7 +92,10 @@ class Command(BaseCommand):
             action="store_true",
             dest="verbose",
             default=False,
-            help="""Sets verbose mode; displays each model built, instead of just schemata.""",
+            help=(
+                "Sets verbose mode; displays each model built, instead of just "
+                "schemata."
+            ),
         )
 
     def get_db(self, options):

--- a/automagic_rest/management/commands/build_data_models.py
+++ b/automagic_rest/management/commands/build_data_models.py
@@ -48,7 +48,9 @@ def fetch_result_with_blank_row(cursor):
     model and column are written in the loop.
     """
     results = cursor.fetchall()
-    results.append(("__BLANK__", "__BLANK__", "__BLANK__", "integer", "__BLANK__", 0, 0))
+    results.append(
+        ("__BLANK__", "__BLANK__", "__BLANK__", "integer", "__BLANK__", 0, 0)
+    )
     desc = cursor.description
     nt_result = namedtuple("Result", [col[0] for col in desc])
 
@@ -239,7 +241,7 @@ class Command(BaseCommand):
         with open(
             f"""{root_path}/models/{context["schema_name"]}.py""", "w"
         ) as f:
-            output = render_to_string(f"automagic_rest/models.html", context)
+            output = render_to_string("automagic_rest/models.html", context)
             f.write(output)
 
     def handle(self, *args, **options):
@@ -318,14 +320,17 @@ class Command(BaseCommand):
                 if decimal_places is None:
                     decimal_places = decimal_places_default
 
-                db_column += f", max_digits={max_digits}, decimal_places={decimal_places}"
+                db_column += (
+                    f", max_digits={max_digits}, decimal_places={decimal_places}"
+                )
 
             if row.data_type in COLUMN_FIELD_MAP:
                 if primary_key_has_been_set:
                     field_map = COLUMN_FIELD_MAP[row.data_type].format("", db_column)
                 else:
-                    # We'll make the first column the primary key, since once is required in the Django ORM
-                    # and this is read-only. Primary keys can not be set to NULL in Django.
+                    # We'll make the first column the primary key, since once is
+                    # required in the Django ORM and this is read-only. Primary keys can
+                    # not be set to NULL in Django.
                     field_map = (
                         COLUMN_FIELD_MAP[row.data_type]
                         .format("primary_key=True", db_column)
@@ -345,5 +350,5 @@ class Command(BaseCommand):
         # Pop off the final false row, and write the URLs file.
         context["routes"].pop()
         with open(f"{root_path}/urls.py", "w") as f:
-            output = render_to_string(f"automagic_rest/urls.html", context)
+            output = render_to_string("automagic_rest/urls.html", context)
             f.write(output)

--- a/automagic_rest/management/commands/build_data_models.py
+++ b/automagic_rest/management/commands/build_data_models.py
@@ -38,7 +38,7 @@ COLUMN_FIELD_MAP = {
     "jsonb": "JSONField({}blank=True, null=True{})",
 }
 
-# Words that can't be used as column  names
+# Words that can't be used as column names
 RESERVED_WORDS = get_reserved_words()
 
 

--- a/automagic_rest/settings.py
+++ b/automagic_rest/settings.py
@@ -1,7 +1,7 @@
 import keyword
 
 
-def get_reserved_words():
+def get_reserved_words_to_append_underscore():
     """
     A list of reserved words list that can not be used for Django field names. This
     includes the Python reserved words list, and additional fields not allowed by

--- a/automagic_rest/settings.py
+++ b/automagic_rest/settings.py
@@ -1,0 +1,16 @@
+import keyword
+
+
+def get_reserved_words():
+    """
+    A list of reserved words list that can not be used for Django field names. This
+    includes the Python reserved words list, and additional fields not allowed by
+    Django REST Framework.
+
+    We will append `_var` to the model field names and map to the underlying database
+    column in the models in the code generator.
+    """
+    reserved_words = keyword.kwlist
+    reserved_words.append("format")
+
+    return reserved_words

--- a/automagic_rest/views.py
+++ b/automagic_rest/views.py
@@ -235,10 +235,10 @@ class GenericViewSet(ReadOnlyModelViewSet):
         Return a dict of keyed column names and their ordinal positions as values.
         """
 
+        RESERVED_WORDS = get_reserved_words()
         positions = {}
 
         cursor = connections[self.db_name].cursor()
-
         cursor.execute(
             """
             SELECT column_name, ordinal_position
@@ -251,6 +251,7 @@ class GenericViewSet(ReadOnlyModelViewSet):
 
         for row in cursor.fetchall():
             # 0 = column_name, 1 = ordinal_position
-            positions[row[0]] = row[1]
+            column_name = f"{row[0]}_" if row[0] in RESERVED_WORDS else row[0]
+            positions[column_name] = row[1]
 
         return positions

--- a/automagic_rest/views.py
+++ b/automagic_rest/views.py
@@ -9,6 +9,7 @@ from rest_framework_filters.backends import (
 )
 
 from .pagination import estimate_count, CountEstimatePagination
+from .settings import get_reserved_words
 
 
 def split_basename(basename):

--- a/automagic_rest/views.py
+++ b/automagic_rest/views.py
@@ -9,7 +9,7 @@ from rest_framework_filters.backends import (
 )
 
 from .pagination import estimate_count, CountEstimatePagination
-from .settings import get_reserved_words
+from .settings import get_reserved_words_to_append_underscore
 
 
 def split_basename(basename):
@@ -235,7 +235,7 @@ class GenericViewSet(ReadOnlyModelViewSet):
         Return a dict of keyed column names and their ordinal positions as values.
         """
 
-        RESERVED_WORDS = get_reserved_words()
+        RESERVED_WORDS = get_reserved_words_to_append_underscore()
         positions = {}
 
         cursor = connections[self.db_name].cursor()


### PR DESCRIPTION
Append an underscore to columns which match a Python reserved words.